### PR TITLE
No single quotes needed for az containerapp create --ingress value

### DIFF
--- a/articles/container-apps/get-started.md
+++ b/articles/container-apps/get-started.md
@@ -83,7 +83,7 @@ az containerapp create \
   --environment $CONTAINERAPPS_ENVIRONMENT \
   --image mcr.microsoft.com/azuredocs/containerapps-helloworld:latest \
   --target-port 80 \
-  --ingress 'external' \
+  --ingress external \
   --query properties.configuration.ingress.fqdn
 ```
 


### PR DESCRIPTION
az containerapp create: ''external'' is not a valid value for '--ingress'. Allowed values: internal, external.